### PR TITLE
Revert "tasks/main.yml: Validate systemd unit files"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,6 @@
   template:
     src: mattermost-mattermail.service.j2
     dest: /etc/systemd/system/mattermost-mattermail.service
-    validate: systemd-analyze verify %s
   notify: Reload systemd daemon
 
 - name: Place Config


### PR DESCRIPTION
Reverts stuvusIT/mattermost-mattermail#3
Validating does not work, because Ansible does not use the correct file suffix in its temp files. That suffix would be needed for systemd to detect the unti type. See https://github.com/ansible/ansible/issues/19232